### PR TITLE
Set default output location on newly parsed configurations if one doe…

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/mta/model/MtaModelParser.java
+++ b/src/main/java/org/jboss/tools/intellij/mta/model/MtaModelParser.java
@@ -53,7 +53,11 @@ public class MtaModelParser {
         }
         String mtaCli = (String)mtaConfiguration.getOptions().get("mta-cli");
         if (mtaCli == null || "".equals(mtaCli)) {
-            mtaConfiguration.getOptions().put("mta-cli", modelService.computeMtaCliLocation());
+            mtaConfiguration.getOptions().put("mta-cli", ModelService.computeMtaCliLocation());
+        }
+        String output = (String)mtaConfiguration.getOptions().get("output");
+        if (output == null || "".equals(output)) {
+            mtaConfiguration.getOptions().put("output", ModelService.getConfigurationOutputLocation(mtaConfiguration));
         }
         return mtaConfiguration;
     }


### PR DESCRIPTION
…s not already exist.